### PR TITLE
feature: 사이렌오더 전체메뉴 구현

### DIFF
--- a/StarbucksClone/StarbucksClone.xcodeproj/project.pbxproj
+++ b/StarbucksClone/StarbucksClone.xcodeproj/project.pbxproj
@@ -34,6 +34,12 @@
 		9A50614F2497509300C303B9 /* MenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A50614E2497509300C303B9 /* MenuButton.swift */; };
 		9A506151249750C200C303B9 /* MenuSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A506150249750C200C303B9 /* MenuSectionHeaderView.swift */; };
 		9ADECD27249CEC49007BDA43 /* AllMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADECD26249CEC49007BDA43 /* AllMenuViewController.swift */; };
+		9ADECD29249D037C007BDA43 /* SlideMenuBeverageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADECD28249D037C007BDA43 /* SlideMenuBeverageCollectionViewCell.swift */; };
+		9ADECD2B249D0387007BDA43 /* SlideMenuFoodCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADECD2A249D0387007BDA43 /* SlideMenuFoodCollectionViewCell.swift */; };
+		9ADECD2D249D0394007BDA43 /* SlideMenuGoodsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADECD2C249D0394007BDA43 /* SlideMenuGoodsCollectionViewCell.swift */; };
+		9ADECD2F249D046D007BDA43 /* SlideMenuLabelCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADECD2E249D046D007BDA43 /* SlideMenuLabelCollectionViewCell.swift */; };
+		9AE76411249E914D00B4865E /* ListMenuTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE76410249E914D00B4865E /* ListMenuTableViewCell.swift */; };
+		9AE76413249E916300B4865E /* ListMenuCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE76412249E916300B4865E /* ListMenuCollectionViewCell.swift */; };
 		A631E2D1248F4C4A00D59A63 /* GSThemeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A631E2D0248F4C4A00D59A63 /* GSThemeViewController.swift */; };
 		A637153A246BE65C00BA74C8 /* GiftShopViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6371539246BE65C00BA74C8 /* GiftShopViewController.swift */; };
 		A6371541246BED0B00BA74C8 /* GSSegmentControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6371540246BED0B00BA74C8 /* GSSegmentControl.swift */; };
@@ -87,6 +93,12 @@
 		9A50614E2497509300C303B9 /* MenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButton.swift; sourceTree = "<group>"; };
 		9A506150249750C200C303B9 /* MenuSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSectionHeaderView.swift; sourceTree = "<group>"; };
 		9ADECD26249CEC49007BDA43 /* AllMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllMenuViewController.swift; sourceTree = "<group>"; };
+		9ADECD28249D037C007BDA43 /* SlideMenuBeverageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideMenuBeverageCollectionViewCell.swift; sourceTree = "<group>"; };
+		9ADECD2A249D0387007BDA43 /* SlideMenuFoodCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideMenuFoodCollectionViewCell.swift; sourceTree = "<group>"; };
+		9ADECD2C249D0394007BDA43 /* SlideMenuGoodsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideMenuGoodsCollectionViewCell.swift; sourceTree = "<group>"; };
+		9ADECD2E249D046D007BDA43 /* SlideMenuLabelCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideMenuLabelCollectionViewCell.swift; sourceTree = "<group>"; };
+		9AE76410249E914D00B4865E /* ListMenuTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListMenuTableViewCell.swift; sourceTree = "<group>"; };
+		9AE76412249E916300B4865E /* ListMenuCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListMenuCollectionViewCell.swift; sourceTree = "<group>"; };
 		A631E2D0248F4C4A00D59A63 /* GSThemeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSThemeViewController.swift; sourceTree = "<group>"; };
 		A6371539246BE65C00BA74C8 /* GiftShopViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftShopViewController.swift; sourceTree = "<group>"; };
 		A6371540246BED0B00BA74C8 /* GSSegmentControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSSegmentControl.swift; sourceTree = "<group>"; };
@@ -215,6 +227,12 @@
 			isa = PBXGroup;
 			children = (
 				9A181301249A466800062F49 /* TabMenuCollectionViewCell.swift */,
+				9ADECD2E249D046D007BDA43 /* SlideMenuLabelCollectionViewCell.swift */,
+				9ADECD28249D037C007BDA43 /* SlideMenuBeverageCollectionViewCell.swift */,
+				9ADECD2A249D0387007BDA43 /* SlideMenuFoodCollectionViewCell.swift */,
+				9ADECD2C249D0394007BDA43 /* SlideMenuGoodsCollectionViewCell.swift */,
+				9AE76410249E914D00B4865E /* ListMenuTableViewCell.swift */,
+				9AE76412249E916300B4865E /* ListMenuCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -502,6 +520,7 @@
 				9A0237BD2497EC7000A4F34E /* FirstBasicInformTableViewCell.swift in Sources */,
 				9A181302249A466800062F49 /* TabMenuCollectionViewCell.swift in Sources */,
 				9A0237B42497E79200A4F34E /* SirenOrderMenuStoryCollectionViewCell.swift in Sources */,
+				9ADECD2B249D0387007BDA43 /* SlideMenuFoodCollectionViewCell.swift in Sources */,
 				9A0237C92497F12000A4F34E /* ChooseSizeCustomButton.swift in Sources */,
 				9A0237C72497F0E100A4F34E /* FifthOptionsTableViewCell.swift in Sources */,
 				A6371541246BED0B00BA74C8 /* GSSegmentControl.swift in Sources */,
@@ -524,6 +543,8 @@
 				9A0237BF2497ECAD00A4F34E /* MenuImageButton.swift in Sources */,
 				A6D966202480CFB20066FFCB /* UIView+Extension.swift in Sources */,
 				A65FC7462472E806009CE4DA /* GSCollectionStyleView.swift in Sources */,
+				9AE76413249E916300B4865E /* ListMenuCollectionViewCell.swift in Sources */,
+				9AE76411249E914D00B4865E /* ListMenuTableViewCell.swift in Sources */,
 				A631E2D1248F4C4A00D59A63 /* GSThemeViewController.swift in Sources */,
 				9A50614F2497509300C303B9 /* MenuButton.swift in Sources */,
 				A6D9661B247F884E0066FFCB /* GSCategoryCollectionCell.swift in Sources */,
@@ -533,6 +554,7 @@
 				A65FC740247290B6009CE4DA /* GSBannerView.swift in Sources */,
 				A65FC74B247601CC009CE4DA /* GSThemeCollectionCell.swift in Sources */,
 				9A0237B02497E57000A4F34E /* SirenOrderMenuTableViewCell.swift in Sources */,
+				9ADECD29249D037C007BDA43 /* SlideMenuBeverageCollectionViewCell.swift in Sources */,
 				A65FC74D24764B73009CE4DA /* GSHomeView.swift in Sources */,
 				9A181304249A467E00062F49 /* TabMenuBar.swift in Sources */,
 				A6D9661E2480B35A0066FFCB /* GSItemByCategoyrCollectionCell.swift in Sources */,
@@ -541,6 +563,8 @@
 				9A0237C12497EEDC00A4F34E /* SecondTemperatureTableViewCell.swift in Sources */,
 				A6D966222480D7750066FFCB /* GiftShopModel.swift in Sources */,
 				9A0237B92497EC4300A4F34E /* MenuDetailViewController.swift in Sources */,
+				9ADECD2D249D0394007BDA43 /* SlideMenuGoodsCollectionViewCell.swift in Sources */,
+				9ADECD2F249D046D007BDA43 /* SlideMenuLabelCollectionViewCell.swift in Sources */,
 				A6D96628248106C00066FFCB /* GSDetailItemView.swift in Sources */,
 				A65FC7492473F4A6009CE4DA /* GSBestNewCollectionCell.swift in Sources */,
 				A65FC74224729884009CE4DA /* GSTagButtonsView.swift in Sources */,

--- a/StarbucksClone/StarbucksClone.xcodeproj/project.pbxproj
+++ b/StarbucksClone/StarbucksClone.xcodeproj/project.pbxproj
@@ -26,11 +26,14 @@
 		9A0237CD2497F21900A4F34E /* SixthOrderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0237CC2497F21900A4F34E /* SixthOrderTableViewCell.swift */; };
 		9A0237CF2497F2B900A4F34E /* SeventhBasketTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0237CE2497F2B900A4F34E /* SeventhBasketTableViewCell.swift */; };
 		9A0237D12497F3CE00A4F34E /* ImageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0237D02497F3CE00A4F34E /* ImageDetailViewController.swift */; };
+		9A181302249A466800062F49 /* TabMenuCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A181301249A466800062F49 /* TabMenuCollectionViewCell.swift */; };
+		9A181304249A467E00062F49 /* TabMenuBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A181303249A467E00062F49 /* TabMenuBar.swift */; };
 		9A506149249747EB00C303B9 /* SirenOrderMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A506148249747EB00C303B9 /* SirenOrderMainViewController.swift */; };
 		9A50614B2497484D00C303B9 /* TopBannerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A50614A2497484D00C303B9 /* TopBannerCollectionViewCell.swift */; };
 		9A50614D2497486700C303B9 /* TopBannerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A50614C2497486700C303B9 /* TopBannerTableViewCell.swift */; };
 		9A50614F2497509300C303B9 /* MenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A50614E2497509300C303B9 /* MenuButton.swift */; };
 		9A506151249750C200C303B9 /* MenuSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A506150249750C200C303B9 /* MenuSectionHeaderView.swift */; };
+		9ADECD27249CEC49007BDA43 /* AllMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADECD26249CEC49007BDA43 /* AllMenuViewController.swift */; };
 		A631E2D1248F4C4A00D59A63 /* GSThemeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A631E2D0248F4C4A00D59A63 /* GSThemeViewController.swift */; };
 		A637153A246BE65C00BA74C8 /* GiftShopViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6371539246BE65C00BA74C8 /* GiftShopViewController.swift */; };
 		A6371541246BED0B00BA74C8 /* GSSegmentControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6371540246BED0B00BA74C8 /* GSSegmentControl.swift */; };
@@ -76,11 +79,14 @@
 		9A0237CC2497F21900A4F34E /* SixthOrderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SixthOrderTableViewCell.swift; sourceTree = "<group>"; };
 		9A0237CE2497F2B900A4F34E /* SeventhBasketTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeventhBasketTableViewCell.swift; sourceTree = "<group>"; };
 		9A0237D02497F3CE00A4F34E /* ImageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailViewController.swift; sourceTree = "<group>"; };
+		9A181301249A466800062F49 /* TabMenuCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMenuCollectionViewCell.swift; sourceTree = "<group>"; };
+		9A181303249A467E00062F49 /* TabMenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMenuBar.swift; sourceTree = "<group>"; };
 		9A506148249747EB00C303B9 /* SirenOrderMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SirenOrderMainViewController.swift; sourceTree = "<group>"; };
 		9A50614A2497484D00C303B9 /* TopBannerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerCollectionViewCell.swift; sourceTree = "<group>"; };
 		9A50614C2497486700C303B9 /* TopBannerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerTableViewCell.swift; sourceTree = "<group>"; };
 		9A50614E2497509300C303B9 /* MenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButton.swift; sourceTree = "<group>"; };
 		9A506150249750C200C303B9 /* MenuSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSectionHeaderView.swift; sourceTree = "<group>"; };
+		9ADECD26249CEC49007BDA43 /* AllMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllMenuViewController.swift; sourceTree = "<group>"; };
 		A631E2D0248F4C4A00D59A63 /* GSThemeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSThemeViewController.swift; sourceTree = "<group>"; };
 		A6371539246BE65C00BA74C8 /* GiftShopViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftShopViewController.swift; sourceTree = "<group>"; };
 		A6371540246BED0B00BA74C8 /* GSSegmentControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSSegmentControl.swift; sourceTree = "<group>"; };
@@ -171,9 +177,52 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		9A1812FA249A45E400062F49 /* AllMenu */ = {
+			isa = PBXGroup;
+			children = (
+				9A1812FB249A45EE00062F49 /* Views */,
+				9A1812FC249A45F300062F49 /* Controller */,
+			);
+			path = AllMenu;
+			sourceTree = "<group>";
+		};
+		9A1812FB249A45EE00062F49 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				9A1812FF249A463300062F49 /* View */,
+				9A181300249A463700062F49 /* Cell */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		9A1812FC249A45F300062F49 /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				9ADECD26249CEC49007BDA43 /* AllMenuViewController.swift */,
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
+		9A1812FF249A463300062F49 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				9A181303249A467E00062F49 /* TabMenuBar.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		9A181300249A463700062F49 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				9A181301249A466800062F49 /* TabMenuCollectionViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		9A50614224973CDD00C303B9 /* SirenOrder */ = {
 			isa = PBXGroup;
 			children = (
+				9A1812FA249A45E400062F49 /* AllMenu */,
 				9A0237B52497EBFE00A4F34E /* MenuDetail */,
 				9A5061432497475E00C303B9 /* Main */,
 			);
@@ -451,6 +500,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A0237BD2497EC7000A4F34E /* FirstBasicInformTableViewCell.swift in Sources */,
+				9A181302249A466800062F49 /* TabMenuCollectionViewCell.swift in Sources */,
 				9A0237B42497E79200A4F34E /* SirenOrderMenuStoryCollectionViewCell.swift in Sources */,
 				9A0237C92497F12000A4F34E /* ChooseSizeCustomButton.swift in Sources */,
 				9A0237C72497F0E100A4F34E /* FifthOptionsTableViewCell.swift in Sources */,
@@ -479,10 +529,12 @@
 				A6D9661B247F884E0066FFCB /* GSCategoryCollectionCell.swift in Sources */,
 				9A506149249747EB00C303B9 /* SirenOrderMainViewController.swift in Sources */,
 				A6D96619247F81130066FFCB /* GSCategoryView.swift in Sources */,
+				9ADECD27249CEC49007BDA43 /* AllMenuViewController.swift in Sources */,
 				A65FC740247290B6009CE4DA /* GSBannerView.swift in Sources */,
 				A65FC74B247601CC009CE4DA /* GSThemeCollectionCell.swift in Sources */,
 				9A0237B02497E57000A4F34E /* SirenOrderMenuTableViewCell.swift in Sources */,
 				A65FC74D24764B73009CE4DA /* GSHomeView.swift in Sources */,
+				9A181304249A467E00062F49 /* TabMenuBar.swift in Sources */,
 				A6D9661E2480B35A0066FFCB /* GSItemByCategoyrCollectionCell.swift in Sources */,
 				9A0237CD2497F21900A4F34E /* SixthOrderTableViewCell.swift in Sources */,
 				9A0237D12497F3CE00A4F34E /* ImageDetailViewController.swift in Sources */,

--- a/StarbucksClone/StarbucksClone/AppDelegate.swift
+++ b/StarbucksClone/StarbucksClone/AppDelegate.swift
@@ -18,10 +18,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
   
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    
     window = UIWindow(frame: UIScreen.main.bounds)
-    let mainVC = UINavigationController(rootViewController: SirenOrderMainViewController()
-    //let mainVC = UINavigationController(rootViewController: MenuDetailViewController()
+    let mainVC = UINavigationController(rootViewController: AllMenuViewController()
+      //let mainVC = UINavigationController(rootViewController: SirenOrderMainViewController()
+      //let mainVC = UINavigationController(rootViewController: MenuDetailViewController()
       
       
       //    let mainVC = UINavigationController(rootViewController:

--- a/StarbucksClone/StarbucksClone/AppDelegate.swift
+++ b/StarbucksClone/StarbucksClone/AppDelegate.swift
@@ -13,6 +13,8 @@ import Kingfisher
 import SnapKit
 
 @UIApplicationMain
+
+
 class AppDelegate: UIResponder, UIApplicationDelegate {
   
   var window: UIWindow?
@@ -20,12 +22,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     window = UIWindow(frame: UIScreen.main.bounds)
     let mainVC = UINavigationController(rootViewController: AllMenuViewController()
-      //let mainVC = UINavigationController(rootViewController: SirenOrderMainViewController()
-      //let mainVC = UINavigationController(rootViewController: MenuDetailViewController()
-      
-      
-      //    let mainVC = UINavigationController(rootViewController:
-      //      GiftShopViewController()
+    //let mainVC = UINavigationController(rootViewController: SirenOrderMainViewController()
+    //let mainVC = UINavigationController(rootViewController: MenuDetailViewController()
+    
+    
+    //let mainVC = UINavigationController(rootViewController: GiftShopViewController()
       //    GSDetailViewController(seletedItem: GiftDetailItem(image: UIImage(named: "test")!, title: "테스트", subtitle: "이것은 테스트", price: 10000),
       //                           otherItems: [
       //                             [UIImage(named: "test")!: "무엇이냐1"],

--- a/StarbucksClone/StarbucksClone/AppDelegate.swift
+++ b/StarbucksClone/StarbucksClone/AppDelegate.swift
@@ -21,8 +21,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     window = UIWindow(frame: UIScreen.main.bounds)
-    let mainVC = UINavigationController(rootViewController: AllMenuViewController()
-    //let mainVC = UINavigationController(rootViewController: SirenOrderMainViewController()
+    //let mainVC = UINavigationController(rootViewController: AllMenuViewController()
+    let mainVC = UINavigationController(rootViewController: SirenOrderMainViewController()
     //let mainVC = UINavigationController(rootViewController: MenuDetailViewController()
     
     

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Controller/AllMenuViewController.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Controller/AllMenuViewController.swift
@@ -9,12 +9,16 @@
 import UIKit
 
 protocol AllMenuVCProtocol: class {
-  func changeTabMenu(scrollTo index: Int)
+  func changeMenu(scrollTo index: Int)
+  //func changeMenuBySlide(section: Int, index: Int)
 }
 
 class AllMenuViewController: UIViewController {
   
   weak var delegate: AllMenuVCProtocol?
+  weak var beverageDelegate: AllMenuVCProtocol?
+  weak var foodDelegate: AllMenuVCProtocol?
+  weak var goodsDelegate: AllMenuVCProtocol?
   
   // MARK: Views
   
@@ -146,12 +150,18 @@ extension AllMenuViewController: UICollectionViewDataSource {
       switch indexPath.item {
       case 0:
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuBeverageCollectionViewCell.identifier, for: indexPath) as? SlideMenuBeverageCollectionViewCell else { return UICollectionViewCell() }
+        cell.delegate = self
+        self.beverageDelegate = cell
         return cell
       case 1:
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuFoodCollectionViewCell.identifier, for: indexPath) as? SlideMenuFoodCollectionViewCell else { return UICollectionViewCell() }
+        cell.delegate = self
+        self.foodDelegate = cell
         return cell
       case 2:
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuGoodsCollectionViewCell.identifier, for: indexPath) as? SlideMenuGoodsCollectionViewCell else { return UICollectionViewCell() }
+        cell.delegate = self
+        self.goodsDelegate = cell
         return cell
       default:
         return UICollectionViewCell()
@@ -191,9 +201,39 @@ extension AllMenuViewController: UICollectionViewDelegateFlowLayout {
   func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
     if scrollView == slideMenuCollectionview {
       let itemAt = Int(targetContentOffset.pointee.x / view.frame.width)
-      delegate?.changeTabMenu(scrollTo: itemAt)
+      delegate?.changeMenu(scrollTo: itemAt)
+      self.listMenuCollectionview.scrollToItem(at: IndexPath(row: 0, section: itemAt), at: .centeredHorizontally, animated: true)
+    } else if scrollView == listMenuCollectionview {
+      let itemAt = Int(targetContentOffset.pointee.x / view.frame.width)
+      switch itemAt {
+      case 0...13:
+        print("음료")
+        // 탭 음료 선택
+        // slide 메뉴 이동!
+        let indexPath = IndexPath(row: 0, section: 0)
+        self.slideMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+        
+        delegate?.changeMenu(scrollTo: 0)
+        
+        beverageDelegate?.changeMenu(scrollTo: itemAt)
+      case 14...22:
+        print("푸드")
+        let indexPath = IndexPath(row: 1, section: 0)
+        self.slideMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+        let index = itemAt - 14
+        delegate?.changeMenu(scrollTo: 1)
+        foodDelegate?.changeMenu(scrollTo: index)
+      case 23...35:
+        print("상품")
+        delegate?.changeMenu(scrollTo: 2)
+        let indexPath = IndexPath(row: 2, section: 0)
+        self.slideMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+        let index = itemAt - 23
+        goodsDelegate?.changeMenu(scrollTo: index)
+      default:
+        print("홀케이크예약")
+      }
     }
-    
   }
 }
 
@@ -204,5 +244,36 @@ extension AllMenuViewController: TabMenuBarProtocol {
       let indexPath = IndexPath(row: index, section: 0)
       self.slideMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
     }
+  }
+  
+  func changeListMenu(scrollTo index: Int) {
+    if index != 3 {
+      let indexPath = IndexPath(row: 0, section: index)
+      self.listMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+    }
+  }
+}
+
+// MARK:- SlideMenuBeverageProtocol
+extension AllMenuViewController: SlideMenuBeverageProtocol {
+  func changeBeverageListMenu(scrollTo index: Int) {
+    let indexPath = IndexPath(row: index, section: 0)
+    self.listMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+  }
+}
+
+// MARK:- SlideMenuFoodProtocol
+extension AllMenuViewController: SlideMenuFoodProtocol {
+  func changeFoodListMenu(scrollTo index: Int) {
+    let indexPath = IndexPath(row: index, section: 1)
+    self.listMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+  }
+}
+
+// MARK:- SlideMenuGoodsProtocol
+extension AllMenuViewController: SlideMenuGoodsProtocol {
+  func changeGoodsListMenu(scrollTo index: Int) {
+    let indexPath = IndexPath(row: index, section: 2)
+    self.listMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
   }
 }

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Controller/AllMenuViewController.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Controller/AllMenuViewController.swift
@@ -8,15 +8,30 @@
 
 import UIKit
 
+protocol AllMenuVCProtocol: class {
+  func changeTabMenu(scrollTo index: Int)
+}
+
 class AllMenuViewController: UIViewController {
-    
+  
+  weak var delegate: AllMenuVCProtocol?
+  
   // MARK: Views
   
   var tabMenuBar = TabMenuBar()
-  private let flowLayout = UICollectionViewFlowLayout().then {
+  private let slideMenuFlowLayout = UICollectionViewFlowLayout().then {
     $0.scrollDirection = .horizontal
   }
-  private lazy var allMenuCollectionview = UICollectionView(frame: .zero, collectionViewLayout: flowLayout).then {
+  private lazy var slideMenuCollectionview = UICollectionView(frame: .zero, collectionViewLayout: slideMenuFlowLayout).then {
+    $0.backgroundColor = .white
+    $0.showsHorizontalScrollIndicator = false
+    $0.isPagingEnabled = true
+  }
+  
+  private let listMenuFlowLayout = UICollectionViewFlowLayout().then {
+    $0.scrollDirection = .horizontal
+  }
+  private lazy var listMenuCollectionview = UICollectionView(frame: .zero, collectionViewLayout: listMenuFlowLayout).then {
     $0.backgroundColor = .white
     $0.showsHorizontalScrollIndicator = false
     $0.isPagingEnabled = true
@@ -36,7 +51,10 @@ class AllMenuViewController: UIViewController {
   
   private func setupAttributes() {
     self.view.backgroundColor = .white
+    self.tabMenuBar.delegate = self
+    self.delegate = tabMenuBar 
     setupNavigationBar()
+    setupCollectionView()
   }
   
   private func setupNavigationBar() {
@@ -57,6 +75,20 @@ class AllMenuViewController: UIViewController {
     navigationItem.rightBarButtonItems = [UIBarButtonItem(customView: orderListButton), UIBarButtonItem(customView: searchBarButton)]
   }
   
+  private func setupCollectionView() {
+    self.slideMenuCollectionview.contentInsetAdjustmentBehavior = .never
+    self.slideMenuCollectionview.dataSource = self
+    self.slideMenuCollectionview.delegate = self
+    self.slideMenuCollectionview.register(SlideMenuBeverageCollectionViewCell.self, forCellWithReuseIdentifier: SlideMenuBeverageCollectionViewCell.identifier)
+    self.slideMenuCollectionview.register(SlideMenuFoodCollectionViewCell.self, forCellWithReuseIdentifier: SlideMenuFoodCollectionViewCell.identifier)
+    self.slideMenuCollectionview.register(SlideMenuGoodsCollectionViewCell.self, forCellWithReuseIdentifier: SlideMenuGoodsCollectionViewCell.identifier)
+    
+    self.listMenuCollectionview.contentInsetAdjustmentBehavior = .never
+    self.listMenuCollectionview.dataSource = self
+    self.listMenuCollectionview.delegate = self
+    self.listMenuCollectionview.register(ListMenuCollectionViewCell.self, forCellWithReuseIdentifier: ListMenuCollectionViewCell.identifier)
+  }
+  
   private func setupConstraints() {
     let guide = view.safeAreaLayoutGuide
     let tabMenuHeight: CGFloat = 58
@@ -66,6 +98,111 @@ class AllMenuViewController: UIViewController {
       .snp.makeConstraints {
         $0.top.leading.trailing.equalTo(guide)
         $0.height.equalTo(tabMenuHeight)
+    }
+    self.slideMenuCollectionview.then { view.addSubview($0) }
+      .snp.makeConstraints {
+        $0.leading.trailing.equalTo(guide)
+        $0.top.equalTo(tabMenuBar.snp.bottom)
+        $0.height.equalTo(60)
+    }
+    self.listMenuCollectionview.then { view.addSubview($0) }
+      .snp.makeConstraints {
+        $0.leading.trailing.bottom.equalTo(guide)
+        $0.top.equalTo(self.slideMenuCollectionview.snp.bottom)
+    }
+  }
+}
+
+// MARK:- UICollectionviewDataSource
+extension AllMenuViewController: UICollectionViewDataSource {
+  func numberOfSections(in collectionView: UICollectionView) -> Int {
+    switch collectionView {
+    case listMenuCollectionview:
+      return 4
+    default:
+      return 1
+    }
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    if collectionView == listMenuCollectionview {
+      switch section {
+      case 0:
+        return 14
+      case 1:
+        return 9
+      case 2:
+        return 13
+      default:
+        return 1
+      }
+    } else {
+      return 3
+    }
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    if collectionView == slideMenuCollectionview {
+      switch indexPath.item {
+      case 0:
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuBeverageCollectionViewCell.identifier, for: indexPath) as? SlideMenuBeverageCollectionViewCell else { return UICollectionViewCell() }
+        return cell
+      case 1:
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuFoodCollectionViewCell.identifier, for: indexPath) as? SlideMenuFoodCollectionViewCell else { return UICollectionViewCell() }
+        return cell
+      case 2:
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuGoodsCollectionViewCell.identifier, for: indexPath) as? SlideMenuGoodsCollectionViewCell else { return UICollectionViewCell() }
+        return cell
+      default:
+        return UICollectionViewCell()
+      }
+    } else {
+      guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ListMenuCollectionViewCell.identifier, for: indexPath) as? ListMenuCollectionViewCell else { return UICollectionViewCell() }
+      return cell
+    }
+  }
+}
+
+// MARK:- UICollectionViewDelegateFlowLayout
+extension AllMenuViewController: UICollectionViewDelegateFlowLayout {
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    if collectionView == slideMenuCollectionview {
+      return CGSize(width: view.frame.width, height: 60)
+    } else {
+      //et heightSize = view.frame.height - tabMenuBar.frame.height - slideMenuCollectionview.frame.height
+      //return CGSize(width: view.frame.width, height: heightSize)
+      return CGSize(width: view.frame.width, height: self.listMenuCollectionview.frame.height)
+    }
+    
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 0
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    return 0
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+  }
+  
+  func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+    if scrollView == slideMenuCollectionview {
+      let itemAt = Int(targetContentOffset.pointee.x / view.frame.width)
+      delegate?.changeTabMenu(scrollTo: itemAt)
+    }
+    
+  }
+}
+
+// MARK:- TabMenuBarProtocol
+extension AllMenuViewController: TabMenuBarProtocol {
+  func changeSlideMenu(scrollTo index: Int) {
+    if index != 3 {
+      let indexPath = IndexPath(row: index, section: 0)
+      self.slideMenuCollectionview.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
     }
   }
 }

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Controller/AllMenuViewController.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Controller/AllMenuViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 
 protocol AllMenuVCProtocol: class {
   func changeMenu(scrollTo index: Int)
-  //func changeMenuBySlide(section: Int, index: Int)
 }
 
 class AllMenuViewController: UIViewController {
@@ -179,11 +178,8 @@ extension AllMenuViewController: UICollectionViewDelegateFlowLayout {
     if collectionView == slideMenuCollectionview {
       return CGSize(width: view.frame.width, height: 60)
     } else {
-      //et heightSize = view.frame.height - tabMenuBar.frame.height - slideMenuCollectionview.frame.height
-      //return CGSize(width: view.frame.width, height: heightSize)
       return CGSize(width: view.frame.width, height: self.listMenuCollectionview.frame.height)
     }
-    
   }
   
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Controller/AllMenuViewController.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Controller/AllMenuViewController.swift
@@ -1,0 +1,71 @@
+//
+//  AllMenuViewController.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/19.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class AllMenuViewController: UIViewController {
+    
+  // MARK: Views
+  
+  var tabMenuBar = TabMenuBar()
+  private let flowLayout = UICollectionViewFlowLayout().then {
+    $0.scrollDirection = .horizontal
+  }
+  private lazy var allMenuCollectionview = UICollectionView(frame: .zero, collectionViewLayout: flowLayout).then {
+    $0.backgroundColor = .white
+    $0.showsHorizontalScrollIndicator = false
+    $0.isPagingEnabled = true
+  }
+  
+  // MARK: Initialize
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupUI()
+  }
+  
+  private func setupUI() {
+    setupAttributes()
+    setupConstraints()
+  }
+  
+  private func setupAttributes() {
+    self.view.backgroundColor = .white
+    setupNavigationBar()
+  }
+  
+  private func setupNavigationBar() {
+    title = "전체 메뉴"
+    navigationController?.navigationBar.tintColor = .white
+    navigationItem.backBarButtonItem = UIBarButtonItem(title: "뒤로", style: .plain, target: self, action: nil)
+    
+    let searchBarButton = UIButton().then {
+      $0.setImage(UIImage(systemName: "magnifyingglass"), for: .normal)
+      $0.imageView?.contentMode = .scaleToFill
+      $0.frame = CGRect(x: 10, y: 0, width: 10, height: 10)
+    }
+    let orderListButton = UIButton().then {
+      $0.setImage(UIImage(systemName: "bag"), for: .normal)
+      $0.imageView?.contentMode = .scaleToFill
+      $0.frame = CGRect(x: 0, y: 0, width: 10, height: 10)
+    }
+    navigationItem.rightBarButtonItems = [UIBarButtonItem(customView: orderListButton), UIBarButtonItem(customView: searchBarButton)]
+  }
+  
+  private func setupConstraints() {
+    let guide = view.safeAreaLayoutGuide
+    let tabMenuHeight: CGFloat = 58
+    
+    tabMenuBar.indicatorViewWidthConstraint?.constant = self.view.frame.width / 4
+    self.tabMenuBar.then { view.addSubview($0) }
+      .snp.makeConstraints {
+        $0.top.leading.trailing.equalTo(guide)
+        $0.height.equalTo(tabMenuHeight)
+    }
+  }
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuCollectionViewCell.swift
@@ -9,5 +9,56 @@
 import UIKit
 
 class ListMenuCollectionViewCell: UICollectionViewCell {
-    
+  
+  // MARK: Property
+  static let identifier = "listMenuCVC"
+  
+  // MARK: Views
+  private var listMenuTableView = UITableView()
+  
+  // MARK: Initialize
+  override init(frame: CGRect) {
+    super .init(frame: frame)
+    setupUI()
+  }
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupUI() {
+    setupAttributes()
+    setupConstraints()
+  }
+  
+  private func setupAttributes() {
+    setupTableView()
+  }
+  
+  private func setupTableView() {
+    self.listMenuTableView.delegate = self
+    self.listMenuTableView.dataSource = self
+    self.listMenuTableView.register(ListMenuTableViewCell.self, forCellReuseIdentifier: ListMenuTableViewCell.identifier)
+  }
+  
+  private func setupConstraints() {
+    self.listMenuTableView.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.top.equalToSuperview()
+        $0.leading.trailing.bottom.equalToSuperview()
+    }
+  }
+}
+
+extension ListMenuCollectionViewCell: UITableViewDataSource {
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return 15
+  }
+  
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    guard let cell = listMenuTableView.dequeueReusableCell(withIdentifier: ListMenuTableViewCell.identifier, for: indexPath) as? ListMenuTableViewCell else { return UITableViewCell() }
+    return cell
+  }
+}
+
+extension ListMenuCollectionViewCell: UITableViewDelegate {
 }

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuCollectionViewCell.swift
@@ -1,0 +1,13 @@
+//
+//  ListMenuCollectionViewCell.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/21.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class ListMenuCollectionViewCell: UICollectionViewCell {
+    
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuTableViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuTableViewCell.swift
@@ -1,0 +1,24 @@
+//
+//  ListMenuTableViewCell.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/21.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class ListMenuTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuTableViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuTableViewCell.swift
@@ -65,7 +65,7 @@ class ListMenuTableViewCell: UITableViewCell {
       .snp.makeConstraints {
         $0.top.leading.equalToSuperview().offset(margin * 1.5)
         $0.width.height.equalTo(70)
-        $0.bottom.equalToSuperview().offset(-margin * 1.5)
+        $0.bottom.equalToSuperview().offset(-margin * 1.5).priority(700)
     }
     self.titleLabel.then { self.contentView.addSubview($0) }
       .snp.makeConstraints {

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuTableViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/ListMenuTableViewCell.swift
@@ -9,16 +9,91 @@
 import UIKit
 
 class ListMenuTableViewCell: UITableViewCell {
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
+  
+  static let identifier = "listMenuTVC"
+  
+  private let menuImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+    $0.layer.cornerRadius = 35
+    $0.clipsToBounds = true
+  }
+  private let titleLabel = UILabel().then {
+    $0.textColor = #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1)
+    $0.font = UIFont.boldSystemFont(ofSize: 14)
+  }
+  private let enTitleLabel = UILabel().then {
+    $0.textColor = #colorLiteral(red: 0.6079670787, green: 0.5307973623, blue: 0.3349733949, alpha: 1)
+    $0.font = UIFont.systemFont(ofSize: 11)
+  }
+  private let giftImage = UIButton().then {
+    let edge: CGFloat = 3
+    $0.setImage(UIImage(systemName: "gift"), for: .normal)
+    $0.tintColor = .white
+    $0.backgroundColor = #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1)
+    $0.imageView?.contentMode = .scaleAspectFit
+    $0.imageView?.clipsToBounds = true
+    $0.imageEdgeInsets = UIEdgeInsets(top: edge, left: edge, bottom: edge, right: edge)
+    $0.layer.cornerRadius = 9
+  }
+  private let priceLabel = UILabel().then {
+    $0.textColor = .black
+    $0.font = UIFont.systemFont(ofSize: 16)
+  }
+  
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupUI() {
+    setupAttributes()
+    setupConstraints()
+  }
+  
+  private func setupAttributes() {
+    self.configure()
+  }
+  
+  private func setupConstraints() {
+    let margin: CGFloat = 10
+    
+    self.menuImageView.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.top.leading.equalToSuperview().offset(margin * 1.5)
+        $0.width.height.equalTo(70)
+        $0.bottom.equalToSuperview().offset(-margin * 1.5)
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+    self.titleLabel.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.top.equalTo(menuImageView).offset(margin)
+        $0.leading.equalTo(menuImageView.snp.trailing).offset(margin * 1.5)
     }
-
+    self.giftImage.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.top.equalTo(titleLabel)
+        $0.leading.equalTo(titleLabel.snp.trailing).offset(5)
+        $0.width.height.equalTo(18)
+    }
+    self.enTitleLabel.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.top.equalTo(titleLabel.snp.bottom).offset(margin / 2)
+        $0.leading.equalTo(titleLabel)
+    }
+    self.priceLabel.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.top.equalTo(enTitleLabel.snp.bottom).offset(margin / 2)
+        $0.leading.equalTo(enTitleLabel)
+    }
+  }
+  
+  func configure() {
+    self.titleLabel.text = "아메리카노"
+    self.enTitleLabel.text = "Caffe Americano"
+    self.priceLabel.text = "4,500원"
+    self.menuImageView.image = UIImage(named: "coffee")
+  }
 }

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuBeverageCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuBeverageCollectionViewCell.swift
@@ -8,9 +8,14 @@
 
 import UIKit
 
+protocol SlideMenuBeverageProtocol: class {
+  func changeBeverageListMenu(scrollTo index: Int)
+}
+
 class SlideMenuBeverageCollectionViewCell: UICollectionViewCell {
   
   // MARK: Property
+  weak var delegate: SlideMenuBeverageProtocol?
   static let identifier = "SlideMenuBeverate"
   private let titles = ["NEW", "추천", "콜드 브루", "리저브", "에스프레소", "디카페인 커피", "블론드", "프라푸치노", "블렌디드", "피지오", "티(티바나)", "브루드 커피", "기타", "병음료"]
   private let viewWidth = UIScreen.main.bounds.width
@@ -113,6 +118,8 @@ extension SlideMenuBeverageCollectionViewCell: UICollectionViewDelegateFlowLayou
   }
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    delegate?.changeBeverageListMenu(scrollTo: indexPath.item)
+    // 아래코드 엄청 중복됨!
     let endPoint = collectionView.contentSize.width - viewWidth
     // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
     
@@ -136,4 +143,37 @@ extension SlideMenuBeverageCollectionViewCell: UICollectionViewDelegateFlowLayou
     collectionView.setContentOffset(newOffset, animated: true)
     previousCell = indexPath.item
   }
+}
+
+// MARK:- AllMenuVCProtocol
+extension SlideMenuBeverageCollectionViewCell: AllMenuVCProtocol {
+  func changeMenu(scrollTo index: Int) {
+    let indexPath = IndexPath(row: index, section: 0)
+    self.beverageCollectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
+    
+    let endPoint = beverageCollectionView.contentSize.width - viewWidth
+    // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
+    
+    var move: CGFloat = 0
+    if indexPath.item > previousCell {
+      move = 60
+    } else if indexPath.item < previousCell {
+      move = -60
+    }
+    
+    var newOffset = CGPoint(x: beverageCollectionView.contentOffset.x + move, y: beverageCollectionView.contentOffset.y)
+    
+    if newOffset.x < 0 {
+      // 맨 앞이면 더이상 움직이지 않게!
+      newOffset.x = 0
+    } else if newOffset.x > endPoint {
+      // 맨 끝이면 더이상 움직이지 않게!
+      newOffset.x = endPoint
+    }
+    
+    beverageCollectionView.setContentOffset(newOffset, animated: true)
+    previousCell = indexPath.item
+  }
+  
+  
 }

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuBeverageCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuBeverageCollectionViewCell.swift
@@ -1,0 +1,139 @@
+//
+//  SlideMenuBeverageCollectionViewCell.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/19.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class SlideMenuBeverageCollectionViewCell: UICollectionViewCell {
+  
+  // MARK: Property
+  static let identifier = "SlideMenuBeverate"
+  private let titles = ["NEW", "추천", "콜드 브루", "리저브", "에스프레소", "디카페인 커피", "블론드", "프라푸치노", "블렌디드", "피지오", "티(티바나)", "브루드 커피", "기타", "병음료"]
+  private let viewWidth = UIScreen.main.bounds.width
+  private var previousCell = 0
+  
+  // MARK: Views
+  private var flowLayout = UICollectionViewFlowLayout().then {
+    $0.scrollDirection = .horizontal
+    } {
+    didSet {
+      flowLayout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+    }
+  }
+  private lazy var beverageCollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout).then {
+    $0.backgroundColor = .clear
+    $0.showsHorizontalScrollIndicator = false
+//    let indexPath = IndexPath(item: 0, section: 0)
+//    $0.selectItem(at: indexPath, animated: false, scrollPosition: [])
+  }
+  private let bottomLine = UIView().then {
+    $0.backgroundColor = #colorLiteral(red: 0.7208426868, green: 0.7233764083, blue: 0.730977573, alpha: 1)
+  }
+  
+  // MARK: Initialize
+  override init(frame: CGRect) {
+    super .init(frame: frame)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupUI() {
+    setupAttributes()
+    setupConstraints()
+  }
+  
+  private func setupAttributes() {
+    setupCollectionView()
+  }
+  
+  private func setupCollectionView() {
+    self.beverageCollectionView.dataSource = self
+    self.beverageCollectionView.delegate = self
+    self.beverageCollectionView.register(SlideMenuLabelCollectionViewCell.self, forCellWithReuseIdentifier: SlideMenuLabelCollectionViewCell.identifier)
+    let indexPath = IndexPath(item: 0, section: 0)
+    self.beverageCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+  }
+  
+  private func setupConstraints() {
+    let margin: CGFloat = 20
+    self.beverageCollectionView.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.centerY.equalToSuperview()
+        $0.leading.trailing.equalToSuperview()
+        $0.height.equalTo(45)
+    }
+    self.bottomLine.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.width.leading.bottom.equalToSuperview()
+        $0.height.equalTo(1)
+    }
+  }
+}
+
+// MARK:- UICollectionViewDataSource
+extension SlideMenuBeverageCollectionViewCell: UICollectionViewDataSource {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return titles.count
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuLabelCollectionViewCell.identifier, for: indexPath) as? SlideMenuLabelCollectionViewCell else { return UICollectionViewCell() }
+    cell.configure(title: "\(titles[indexPath.item])")
+    return cell
+  }
+}
+
+// MARK:- UICollectionViewDelegateFlowLayout
+extension SlideMenuBeverageCollectionViewCell: UICollectionViewDelegateFlowLayout {
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    let label = UILabel(frame: CGRect.zero)
+    label.text = titles[indexPath.item]
+    label.sizeToFit()
+    return CGSize(width: label.frame.width + 12, height: label.frame.height + 6)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 0
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    return 12
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    let endPoint = collectionView.contentSize.width - viewWidth
+    // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
+    
+    var move: CGFloat = 0
+    if indexPath.item > previousCell {
+      move = 60
+    } else if indexPath.item < previousCell {
+      move = -60
+    }
+    
+    var newOffset = CGPoint(x: collectionView.contentOffset.x + move, y: collectionView.contentOffset.y)
+    
+    if newOffset.x < 0 {
+      // 맨 앞이면 더이상 움직이지 않게!
+      newOffset.x = 0
+    } else if newOffset.x > endPoint {
+      // 맨 끝이면 더이상 움직이지 않게!
+      newOffset.x = endPoint
+    }
+    
+    collectionView.setContentOffset(newOffset, animated: true)
+    previousCell = indexPath.item
+  }
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuBeverageCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuBeverageCollectionViewCell.swift
@@ -67,7 +67,6 @@ class SlideMenuBeverageCollectionViewCell: UICollectionViewCell {
   }
   
   private func setupConstraints() {
-    let margin: CGFloat = 20
     self.beverageCollectionView.then { self.contentView.addSubview($0) }
       .snp.makeConstraints {
         $0.centerY.equalToSuperview()
@@ -119,7 +118,7 @@ extension SlideMenuBeverageCollectionViewCell: UICollectionViewDelegateFlowLayou
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     delegate?.changeBeverageListMenu(scrollTo: indexPath.item)
-    // 아래코드 엄청 중복됨!
+    // 아래코드 엄청 중복됨 수정하기!
     let endPoint = collectionView.contentSize.width - viewWidth
     // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
     

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuFoodCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuFoodCollectionViewCell.swift
@@ -167,7 +167,6 @@ extension SlideMenuFoodCollectionViewCell: AllMenuVCProtocol {
         // 맨 끝이면 더이상 움직이지 않게!
         newOffset.x = endPoint
       }
-      
       foodCollectionView.setContentOffset(newOffset, animated: true)
       previousCell = indexPath.item
   }

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuFoodCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuFoodCollectionViewCell.swift
@@ -1,0 +1,138 @@
+//
+//  SlideMenuFoodCollectionViewCell.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/19.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class SlideMenuFoodCollectionViewCell: UICollectionViewCell {
+  
+  // MARK: Property
+  static let identifier = "SlideMenuFood"
+  private let titles = ["New", "추천", "베이커리", "케이크", "샌드위치&샐러드", "따뜻한 푸드", "과일&요거트", "스낵&미니디저트", "아이스크림"]
+  private let viewWidth = UIScreen.main.bounds.width
+  private var previousCell = 0
+  
+  // MARK: Views
+  private var flowLayout = UICollectionViewFlowLayout().then {
+    $0.scrollDirection = .horizontal
+    } {
+    didSet {
+      flowLayout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+    }
+  }
+  private lazy var foodCollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout).then {
+    $0.backgroundColor = .clear
+    $0.showsHorizontalScrollIndicator = false
+    let indexPath = IndexPath(item: 0, section: 0)
+    $0.selectItem(at: indexPath, animated: false, scrollPosition: [])
+  }
+  private let bottomLine = UIView().then {
+    $0.backgroundColor = #colorLiteral(red: 0.7208426868, green: 0.7233764083, blue: 0.730977573, alpha: 1)
+  }
+  
+  // MARK: Initialize
+  override init(frame: CGRect) {
+    super .init(frame: frame)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupUI() {
+    setupAttributes()
+    setupConstraints()
+  }
+  
+  private func setupAttributes() {
+    setupCollectionView()
+  }
+  
+  private func setupCollectionView() {
+    self.foodCollectionView.dataSource = self
+    self.foodCollectionView.delegate = self
+    self.foodCollectionView.register(SlideMenuLabelCollectionViewCell.self, forCellWithReuseIdentifier: SlideMenuLabelCollectionViewCell.identifier)
+    let indexPath = IndexPath(item: 0, section: 0)
+    self.foodCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+  }
+  
+  private func setupConstraints() {
+    self.foodCollectionView.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.centerY.equalToSuperview()
+        $0.leading.trailing.equalToSuperview()
+        $0.height.equalTo(45)
+    }
+    self.bottomLine.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.width.leading.bottom.equalToSuperview()
+        $0.height.equalTo(1)
+    }
+  }
+}
+
+// MARK:- UICollectionViewDataSource
+extension SlideMenuFoodCollectionViewCell: UICollectionViewDataSource {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return titles.count
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuLabelCollectionViewCell.identifier, for: indexPath) as? SlideMenuLabelCollectionViewCell else { return UICollectionViewCell() }
+    cell.configure(title: "\(titles[indexPath.item])")
+    return cell
+  }
+}
+
+// MARK:- UICollectionViewDelegateFlowLayout
+extension SlideMenuFoodCollectionViewCell: UICollectionViewDelegateFlowLayout {
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    let label = UILabel(frame: CGRect.zero)
+    label.text = titles[indexPath.item]
+    label.sizeToFit()
+    return CGSize(width: label.frame.width + 12, height: label.frame.height + 4)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 0
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    return 12
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    let endPoint = collectionView.contentSize.width - viewWidth
+    // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
+    
+    var move: CGFloat = 0
+    if indexPath.item > previousCell {
+      move = 60
+    } else if indexPath.item < previousCell {
+      move = -60
+    }
+    
+    var newOffset = CGPoint(x: collectionView.contentOffset.x + move, y: collectionView.contentOffset.y)
+    
+    if newOffset.x < 0 {
+      // 맨 앞이면 더이상 움직이지 않게!
+      newOffset.x = 0
+    } else if newOffset.x > endPoint {
+      // 맨 끝이면 더이상 움직이지 않게!
+      newOffset.x = endPoint
+    }
+    
+    collectionView.setContentOffset(newOffset, animated: true)
+    previousCell = indexPath.item
+  }
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuFoodCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuFoodCollectionViewCell.swift
@@ -8,9 +8,14 @@
 
 import UIKit
 
+protocol SlideMenuFoodProtocol: class {
+  func changeFoodListMenu(scrollTo index: Int)
+}
+
 class SlideMenuFoodCollectionViewCell: UICollectionViewCell {
   
   // MARK: Property
+  weak var delegate: SlideMenuFoodProtocol?
   static let identifier = "SlideMenuFood"
   private let titles = ["New", "추천", "베이커리", "케이크", "샌드위치&샐러드", "따뜻한 푸드", "과일&요거트", "스낵&미니디저트", "아이스크림"]
   private let viewWidth = UIScreen.main.bounds.width
@@ -112,6 +117,7 @@ extension SlideMenuFoodCollectionViewCell: UICollectionViewDelegateFlowLayout {
   }
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    delegate?.changeFoodListMenu(scrollTo: indexPath.item)
     let endPoint = collectionView.contentSize.width - viewWidth
     // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
     
@@ -134,5 +140,35 @@ extension SlideMenuFoodCollectionViewCell: UICollectionViewDelegateFlowLayout {
     
     collectionView.setContentOffset(newOffset, animated: true)
     previousCell = indexPath.item
+  }
+}
+
+extension SlideMenuFoodCollectionViewCell: AllMenuVCProtocol {
+  func changeMenu(scrollTo index: Int) {
+    let indexPath = IndexPath(row: index, section: 0)
+      self.foodCollectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
+      
+      let endPoint = foodCollectionView.contentSize.width - viewWidth
+      // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
+      
+      var move: CGFloat = 0
+      if indexPath.item > previousCell {
+        move = 60
+      } else if indexPath.item < previousCell {
+        move = -60
+      }
+      
+      var newOffset = CGPoint(x: foodCollectionView.contentOffset.x + move, y: foodCollectionView.contentOffset.y)
+      
+      if newOffset.x < 0 {
+        // 맨 앞이면 더이상 움직이지 않게!
+        newOffset.x = 0
+      } else if newOffset.x > endPoint {
+        // 맨 끝이면 더이상 움직이지 않게!
+        newOffset.x = endPoint
+      }
+      
+      foodCollectionView.setContentOffset(newOffset, animated: true)
+      previousCell = indexPath.item
   }
 }

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuGoodsCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuGoodsCollectionViewCell.swift
@@ -1,0 +1,136 @@
+//
+//  SlideMenuGoodsCollectionViewCell.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/19.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class SlideMenuGoodsCollectionViewCell: UICollectionViewCell {
+  // MARK: Property
+  static let identifier = "SlideMenuGoods"
+  private let titles = ["New", "추천", "머그/글라스", "스테인리스텀블러", "플라스틱텀블러", "보온병", "액세서리", "커피용품", "원두", "오리가미", "비아", "패키지 티", "리저브 원두"]
+  private let viewWidth = UIScreen.main.bounds.width
+  private var previousCell = 0
+  
+  // MARK: Views
+  private var flowLayout = UICollectionViewFlowLayout().then {
+    $0.scrollDirection = .horizontal
+    } {
+    didSet {
+      flowLayout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+    }
+  }
+  private lazy var goodsCollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout).then {
+    $0.backgroundColor = .clear
+    $0.showsHorizontalScrollIndicator = false
+  }
+  private let bottomLine = UIView().then {
+    $0.backgroundColor = #colorLiteral(red: 0.7208426868, green: 0.7233764083, blue: 0.730977573, alpha: 1)
+  }
+  
+  // MARK: Initialize
+  override init(frame: CGRect) {
+    super .init(frame: frame)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupUI() {
+    setupAttributes()
+    setupConstraints()
+  }
+  
+  private func setupAttributes() {
+    setupCollectionView()
+  }
+  
+  private func setupCollectionView() {
+    self.goodsCollectionView.dataSource = self
+    self.goodsCollectionView.delegate = self
+    self.goodsCollectionView.register(SlideMenuLabelCollectionViewCell.self, forCellWithReuseIdentifier: SlideMenuLabelCollectionViewCell.identifier)
+    let indexPath = IndexPath(item: 0, section: 0)
+    self.goodsCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+  }
+  
+  private func setupConstraints() {
+    self.goodsCollectionView.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.centerY.equalToSuperview()
+        $0.leading.trailing.equalToSuperview()
+        $0.height.equalTo(45)
+    }
+    self.bottomLine.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.width.leading.bottom.equalToSuperview()
+        $0.height.equalTo(1)
+    }
+  }
+}
+
+// MARK:- UICollectionViewDataSource
+extension SlideMenuGoodsCollectionViewCell: UICollectionViewDataSource {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return titles.count
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SlideMenuLabelCollectionViewCell.identifier, for: indexPath) as? SlideMenuLabelCollectionViewCell else { return UICollectionViewCell() }
+    cell.configure(title: "\(titles[indexPath.item])")
+    return cell
+  }
+}
+
+// MARK:- UICollectionViewDelegateFlowLayout
+extension SlideMenuGoodsCollectionViewCell: UICollectionViewDelegateFlowLayout {
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    let label = UILabel(frame: CGRect.zero)
+    label.text = titles[indexPath.item]
+    label.sizeToFit()
+    return CGSize(width: label.frame.width + 12, height: label.frame.height + 4)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 0
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    return 12
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    let endPoint = collectionView.contentSize.width - viewWidth
+    // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
+    
+    var move: CGFloat = 0
+    if indexPath.item > previousCell {
+      move = 60
+    } else if indexPath.item < previousCell {
+      move = -60
+    }
+    
+    var newOffset = CGPoint(x: collectionView.contentOffset.x + move, y: collectionView.contentOffset.y)
+    
+    if newOffset.x < 0 {
+      // 맨 앞이면 더이상 움직이지 않게!
+      newOffset.x = 0
+    } else if newOffset.x > endPoint {
+      // 맨 끝이면 더이상 움직이지 않게!
+      newOffset.x = endPoint
+    }
+    
+    collectionView.setContentOffset(newOffset, animated: true)
+    previousCell = indexPath.item
+  }
+}
+

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuGoodsCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuGoodsCollectionViewCell.swift
@@ -8,8 +8,13 @@
 
 import UIKit
 
+protocol SlideMenuGoodsProtocol: class {
+  func changeGoodsListMenu(scrollTo index: Int)
+}
+
 class SlideMenuGoodsCollectionViewCell: UICollectionViewCell {
   // MARK: Property
+  weak var delegate: SlideMenuGoodsProtocol?
   static let identifier = "SlideMenuGoods"
   private let titles = ["New", "추천", "머그/글라스", "스테인리스텀블러", "플라스틱텀블러", "보온병", "액세서리", "커피용품", "원두", "오리가미", "비아", "패키지 티", "리저브 원두"]
   private let viewWidth = UIScreen.main.bounds.width
@@ -109,6 +114,7 @@ extension SlideMenuGoodsCollectionViewCell: UICollectionViewDelegateFlowLayout {
   }
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    delegate?.changeGoodsListMenu(scrollTo: indexPath.item)
     let endPoint = collectionView.contentSize.width - viewWidth
     // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
     
@@ -134,3 +140,32 @@ extension SlideMenuGoodsCollectionViewCell: UICollectionViewDelegateFlowLayout {
   }
 }
 
+extension SlideMenuGoodsCollectionViewCell: AllMenuVCProtocol {
+  func changeMenu(scrollTo index: Int) {
+    let indexPath = IndexPath(row: index, section: 0)
+    self.goodsCollectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
+    
+    let endPoint = goodsCollectionView.contentSize.width - viewWidth
+    // -viewWidth를 해주는 이유는 화면시작점의 contentOffset.x를 알고 싶으니까. size는 화면 끝까지의 길이가 나옴
+    
+    var move: CGFloat = 0
+    if indexPath.item > previousCell {
+      move = 60
+    } else if indexPath.item < previousCell {
+      move = -60
+    }
+    
+    var newOffset = CGPoint(x: goodsCollectionView.contentOffset.x + move, y: goodsCollectionView.contentOffset.y)
+    
+    if newOffset.x < 0 {
+      // 맨 앞이면 더이상 움직이지 않게!
+      newOffset.x = 0
+    } else if newOffset.x > endPoint {
+      // 맨 끝이면 더이상 움직이지 않게!
+      newOffset.x = endPoint
+    }
+    
+    goodsCollectionView.setContentOffset(newOffset, animated: true)
+    previousCell = indexPath.item
+  }
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuLabelCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuLabelCollectionViewCell.swift
@@ -1,0 +1,61 @@
+//
+//  SlideMenuLabelCollectionViewCell.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/19.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class SlideMenuLabelCollectionViewCell: UICollectionViewCell {
+  
+  static let identifier = "SlideMenuLabel"
+  
+  // MARK: Views
+  
+  private var titleLabel = UILabel().then {
+    $0.textColor = #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1)
+    $0.font = UIFont.systemFont(ofSize: 15)
+    $0.textAlignment = .center
+    $0.backgroundColor = .clear
+    $0.layer.borderColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+    $0.layer.cornerRadius = 13
+    $0.clipsToBounds = true
+  }
+  
+  // MARK: Initialize
+  
+  override init(frame: CGRect) {
+    super .init(frame: frame)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupUI() {
+    setupConstraints()
+  }
+  
+  override var isSelected: Bool {
+    didSet {
+      self.titleLabel.textColor = isSelected ? .white : #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1)
+      self.titleLabel.backgroundColor = isSelected ? #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1) : .white
+    }
+  }
+  
+  private func setupConstraints() {
+    self.titleLabel.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.centerX.centerY.equalToSuperview()
+        $0.width.height.equalToSuperview()
+        //$0.height.equalTo(21)
+    }
+  }
+  
+  func configure(title: String) {
+    self.titleLabel.text = title
+  }
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuLabelCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/SlideMenuLabelCollectionViewCell.swift
@@ -51,7 +51,6 @@ class SlideMenuLabelCollectionViewCell: UICollectionViewCell {
       .snp.makeConstraints {
         $0.centerX.centerY.equalToSuperview()
         $0.width.height.equalToSuperview()
-        //$0.height.equalTo(21)
     }
   }
   

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/TabMenuCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/TabMenuCollectionViewCell.swift
@@ -16,7 +16,7 @@ class TabMenuCollectionViewCell: UICollectionViewCell {
   
   var tabMenuLabel = UILabel().then {
     $0.textAlignment = .center
-    $0.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+    $0.font = UIFont.systemFont(ofSize: 15, weight: .medium)
     $0.textColor = #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1)
   }
   

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/TabMenuCollectionViewCell.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/Cell/TabMenuCollectionViewCell.swift
@@ -1,0 +1,56 @@
+//
+//  TabMenuCollectionViewCell.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/17.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class TabMenuCollectionViewCell: UICollectionViewCell {
+  
+  // MARK: Property
+  
+  static let identifier = "TabMenuBarCell"
+  
+  var tabMenuLabel = UILabel().then {
+    $0.textAlignment = .center
+    $0.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+    $0.textColor = #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1)
+  }
+  
+  // MARK: Initialize
+  
+  override init(frame: CGRect) {
+    super .init(frame: frame)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupUI() {
+    setupConstraints()
+  }
+  
+  override var isSelected: Bool {
+    didSet {
+      self.tabMenuLabel.textColor = isSelected ? #colorLiteral(red: 0.6079670787, green: 0.5307973623, blue: 0.3349733949, alpha: 1) : .darkGray
+    }
+  }
+  
+  private func setupConstraints() {
+    self.tabMenuLabel.then { self.contentView.addSubview($0) }
+      .snp.makeConstraints {
+        $0.centerX.centerY.equalToSuperview()
+    }
+  }
+  
+  // MARK: Interface
+  
+  func configure(title: String) {
+    self.tabMenuLabel.text = title
+  }
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/View/TabMenuBar.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/View/TabMenuBar.swift
@@ -10,6 +10,7 @@ import UIKit
 
 protocol TabMenuBarProtocol: class {
   func changeSlideMenu(scrollTo index: Int)
+  func changeListMenu(scrollTo index: Int)
 }
 
 class TabMenuBar: UIView {
@@ -135,6 +136,7 @@ extension TabMenuBar: UICollectionViewDelegateFlowLayout {
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     guard let cell = collectionView.cellForItem(at: indexPath) as? TabMenuCollectionViewCell else { return }
     delegate?.changeSlideMenu(scrollTo: indexPath.item)
+    delegate?.changeListMenu(scrollTo: indexPath.item)
     cell.tabMenuLabel.textColor = #colorLiteral(red: 0.6079670787, green: 0.5307973623, blue: 0.3349733949, alpha: 1)
     switch indexPath.item {
     case 3:
@@ -156,7 +158,7 @@ extension TabMenuBar: UICollectionViewDelegateFlowLayout {
 }
 
 extension TabMenuBar: AllMenuVCProtocol {
-  func changeTabMenu(scrollTo index: Int) {
+  func changeMenu(scrollTo index: Int) {
     let indexPath = IndexPath(item: index, section: 0)
     self.tabMenuCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
     

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/View/TabMenuBar.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/View/TabMenuBar.swift
@@ -1,0 +1,153 @@
+//
+//  TabMenuBar.swift
+//  StarbucksClone
+//
+//  Created by Mac mini on 2020/06/17.
+//  Copyright © 2020 momo. All rights reserved.
+//
+
+import UIKit
+
+class TabMenuBar: UIView {
+  // MARK: Property
+  
+  private let viewWidth = UIScreen.main.bounds.width
+  private let titles = ["음료", "푸드", "상품", "홀케이크 예약"]
+  var indicatorViewLeadingConstraint: NSLayoutConstraint?
+  var indicatorViewWidthConstraint: NSLayoutConstraint?
+  private let cakeReservesize: CGFloat = UIScreen.main.bounds.width / 4 + 30
+  private let restSize: CGFloat = (UIScreen.main.bounds.width - (UIScreen.main.bounds.width / 4 + 30)) / 3
+  //  private let cakeReservesize: CGFloat = collectionView.frame.size.width / 4 + 30
+  //  private let restSize: CGFloat = (collectionView.frame.size.width - cakeReservesize) / 3
+  
+  // MARK: Views
+  
+  private let flowLayout = UICollectionViewFlowLayout().then {
+    $0.scrollDirection = .horizontal
+  }
+  private lazy var tabMenuCollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout).then {
+    $0.showsHorizontalScrollIndicator = false
+    $0.backgroundColor = .white
+    $0.isScrollEnabled = false
+  }
+  private var indicatorView = UIView().then {
+    $0.backgroundColor = #colorLiteral(red: 0.6079670787, green: 0.5307973623, blue: 0.3349733949, alpha: 1)
+  }
+  private let bottomLine = UIView().then {
+    $0.backgroundColor = #colorLiteral(red: 0.7208426868, green: 0.7233764083, blue: 0.730977573, alpha: 1)
+  }
+  
+  // MARK: Initialize
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupUI() {
+    setupAttributes()
+    setupConstraints()
+  }
+  
+  private func setupAttributes() {
+    setupCollectionView()
+    
+  }
+  
+  private func setupCollectionView() {
+    self.tabMenuCollectionView.dataSource = self
+    self.tabMenuCollectionView.delegate = self
+    self.tabMenuCollectionView.register(TabMenuCollectionViewCell.self, forCellWithReuseIdentifier: TabMenuCollectionViewCell.identifier)
+    let indexPath = IndexPath(item: 0, section: 0)
+    self.tabMenuCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+  }
+  
+  private func setupConstraints() {
+    let indicatorHeight: CGFloat = 3
+    
+    self.tabMenuCollectionView.then { self.addSubview($0) }
+      .snp.makeConstraints {
+        $0.top.leading.trailing.equalTo(self)
+    }
+    self.indicatorView.then { self.addSubview($0) }
+      .snp.makeConstraints {
+        $0.height.equalTo(indicatorHeight)
+        $0.top.equalTo(self.tabMenuCollectionView.snp.bottom)
+    }
+    self.bottomLine.then { self.addSubview($0) }
+      .snp.makeConstraints {
+        $0.width.leading.bottom.equalToSuperview()
+        $0.height.equalTo(0.5)
+        $0.top.equalTo(indicatorView.snp.bottom)
+    }
+    
+    self.indicatorView.translatesAutoresizingMaskIntoConstraints = false
+    self.indicatorViewLeadingConstraint = self.indicatorView.leadingAnchor.constraint(equalTo: self.leadingAnchor)
+    self.indicatorViewLeadingConstraint?.isActive = true
+    self.indicatorViewWidthConstraint = self.indicatorView.widthAnchor.constraint(equalToConstant: restSize)
+    self.indicatorViewWidthConstraint?.isActive = true
+  }
+}
+
+// MARK:- UICollectionViewDelegate
+extension TabMenuBar: UICollectionViewDataSource {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return 4
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TabMenuCollectionViewCell.identifier, for: indexPath) as? TabMenuCollectionViewCell else { return UICollectionViewCell() }
+    cell.configure(title: titles[indexPath.item])
+    return cell
+  }
+}
+
+// MARK:- UICollectionViewDelegateFlowLayout
+extension TabMenuBar: UICollectionViewDelegateFlowLayout {
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    switch indexPath.item {
+    case 3:
+      return CGSize(width: cakeReservesize, height: collectionView.frame.size.height)
+    default:
+      return CGSize(width: restSize, height: collectionView.frame.size.height)
+    }
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 0
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    return 0
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard let cell = collectionView.cellForItem(at: indexPath) as? TabMenuCollectionViewCell else { return }
+    cell.tabMenuLabel.textColor = #colorLiteral(red: 0.6079670787, green: 0.5307973623, blue: 0.3349733949, alpha: 1)
+    
+    switch indexPath.item {
+    case 3:
+      self.indicatorViewLeadingConstraint?.constant = CGFloat(Int(restSize) * indexPath.item) + 5
+      self.indicatorViewWidthConstraint?.constant = cakeReservesize
+    default:
+      self.indicatorViewLeadingConstraint?.constant = CGFloat(Int(restSize) * indexPath.item)
+      self.indicatorViewWidthConstraint?.constant = restSize
+    }
+    UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+      self.layoutIfNeeded()
+    }, completion: nil)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+    guard let cell = collectionView.cellForItem(at: indexPath) as? TabMenuCollectionViewCell else { return }
+    cell.tabMenuLabel.textColor = #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1)
+  }
+}

--- a/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/View/TabMenuBar.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/AllMenu/Views/View/TabMenuBar.swift
@@ -8,17 +8,20 @@
 
 import UIKit
 
+protocol TabMenuBarProtocol: class {
+  func changeSlideMenu(scrollTo index: Int)
+}
+
 class TabMenuBar: UIView {
   // MARK: Property
   
+  weak var delegate: TabMenuBarProtocol?
   private let viewWidth = UIScreen.main.bounds.width
   private let titles = ["음료", "푸드", "상품", "홀케이크 예약"]
   var indicatorViewLeadingConstraint: NSLayoutConstraint?
   var indicatorViewWidthConstraint: NSLayoutConstraint?
   private let cakeReservesize: CGFloat = UIScreen.main.bounds.width / 4 + 30
   private let restSize: CGFloat = (UIScreen.main.bounds.width - (UIScreen.main.bounds.width / 4 + 30)) / 3
-  //  private let cakeReservesize: CGFloat = collectionView.frame.size.width / 4 + 30
-  //  private let restSize: CGFloat = (collectionView.frame.size.width - cakeReservesize) / 3
   
   // MARK: Views
   
@@ -81,7 +84,7 @@ class TabMenuBar: UIView {
     self.bottomLine.then { self.addSubview($0) }
       .snp.makeConstraints {
         $0.width.leading.bottom.equalToSuperview()
-        $0.height.equalTo(0.5)
+        $0.height.equalTo(1)
         $0.top.equalTo(indicatorView.snp.bottom)
     }
     
@@ -131,8 +134,8 @@ extension TabMenuBar: UICollectionViewDelegateFlowLayout {
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     guard let cell = collectionView.cellForItem(at: indexPath) as? TabMenuCollectionViewCell else { return }
+    delegate?.changeSlideMenu(scrollTo: indexPath.item)
     cell.tabMenuLabel.textColor = #colorLiteral(red: 0.6079670787, green: 0.5307973623, blue: 0.3349733949, alpha: 1)
-    
     switch indexPath.item {
     case 3:
       self.indicatorViewLeadingConstraint?.constant = CGFloat(Int(restSize) * indexPath.item) + 5
@@ -149,5 +152,24 @@ extension TabMenuBar: UICollectionViewDelegateFlowLayout {
   func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
     guard let cell = collectionView.cellForItem(at: indexPath) as? TabMenuCollectionViewCell else { return }
     cell.tabMenuLabel.textColor = #colorLiteral(red: 0.4032030404, green: 0.3995964527, blue: 0.399479419, alpha: 1)
+  }
+}
+
+extension TabMenuBar: AllMenuVCProtocol {
+  func changeTabMenu(scrollTo index: Int) {
+    let indexPath = IndexPath(item: index, section: 0)
+    self.tabMenuCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+    
+    switch index {
+    case 3:
+      self.indicatorViewLeadingConstraint?.constant = CGFloat(Int(restSize) * index) + 5
+      self.indicatorViewWidthConstraint?.constant = cakeReservesize
+    default:
+      self.indicatorViewLeadingConstraint?.constant = CGFloat(Int(restSize) * index)
+      self.indicatorViewWidthConstraint?.constant = restSize
+    }
+    UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+      self.layoutIfNeeded()
+    }, completion: nil)
   }
 }

--- a/StarbucksClone/StarbucksClone/SirenOrder/Main/Controller/SirenOrderMainViewController.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/Main/Controller/SirenOrderMainViewController.swift
@@ -104,6 +104,7 @@ extension SirenOrderMainViewController: UITableViewDataSource {
     switch section {
     case 1:
       let menuView = MenuSectionHeaderView()
+      menuView.delegate = self
       return menuView
     default:
       return nil
@@ -147,5 +148,13 @@ extension SirenOrderMainViewController: SirenOrderTableViewProtocol {
   func showDetailPage() {
     let menuDetailVC = MenuDetailViewController()
     navigationController?.pushViewController(menuDetailVC, animated: true)
+  }
+}
+
+// MARK:- MenuSectionHeaderProtocol
+extension SirenOrderMainViewController: MenuSectionHeaderProtocol {
+  func pushAllMenu() {
+    let allMenuVC = AllMenuViewController()
+    navigationController?.pushViewController(allMenuVC, animated: true)
   }
 }

--- a/StarbucksClone/StarbucksClone/SirenOrder/Main/Views/View/MenuSectionHeaderView.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/Main/Views/View/MenuSectionHeaderView.swift
@@ -8,7 +8,14 @@
 
 import UIKit
 
+protocol MenuSectionHeaderProtocol: class {
+  func pushAllMenu()
+}
+
 class MenuSectionHeaderView: UIView {
+  
+  weak var delegate: MenuSectionHeaderProtocol?
+  
   // MARK: Views
   
   private let backView = UIView().then {
@@ -102,6 +109,7 @@ class MenuSectionHeaderView: UIView {
     switch sender {
     case allMenuButton:
       print("전체 메뉴")
+      delegate?.pushAllMenu()
     case myMenuButton:
       print("나만의 메뉴")
     case historyButton:

--- a/StarbucksClone/StarbucksClone/SirenOrder/MenuDetail/Views/View/PersonalOptionCustomButton.swift
+++ b/StarbucksClone/StarbucksClone/SirenOrder/MenuDetail/Views/View/PersonalOptionCustomButton.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class PersonalOptionCustomButton: UIButton {
+  
   // MARK: Views
   private let personalOptionLabel = UILabel().then {
     $0.text = "퍼스널 옵션"


### PR DESCRIPTION
1. 탭버튼 구현
	- 최상단의 탭버튼(음료, 푸드, 상품, 홀케이크 예약) 구현
2. slide 메뉴 구현
	- collectionView 중첩해서 slide메뉴 구현
3. list 메뉴 구현
	- collectionView 안에 tableView를 담에 slide메뉴에 해당하는 list메뉴 구현
4. delegation 추가
	- 탭 메뉴 선택시 해당하는 슬라이드 메뉴, 리스트 메뉴 이동
	- 슬라이드 메뉴 선택 및 스크롤 시, 해당하는 탭메뉴, 리스트 메뉴 이동
	- 리스트 메뉴 스크롤시, 해당하는 탭메뉴와 슬라이드 메뉴로 이동
5. 화면 연결
	- delegation 이용하여 사이렌오더 메인과 전체메뉴 화면 연결

* 홀케이크 예약 부분 아직 미구현
* 사이렌오더 메인의 [전체메뉴, 나만의 메뉴, 히스토리] 버튼 상단에 고정될 때 배경색 흰색으로 바뀌도록 수정할 예정
* 전체메뉴의 slideMenu코드 중 중복되는 코드(메뉴 버튼 클릭 시 contentsoffset 자동 이동하는 부분) 수정 예정